### PR TITLE
Fix URL encoding issue

### DIFF
--- a/src/googl.coffee
+++ b/src/googl.coffee
@@ -20,7 +20,7 @@ module.exports = (robot) ->
 
     robot.respond /shorten (.+)/i, (res) ->
         data = JSON.stringify
-            longUrl: encodeURIComponent(res.match[1])
+            longUrl: res.match[1]
 
         params = {}
         params.key = GOOGLE_API_KEY if GOOGLE_API_KEY?


### PR DESCRIPTION
Google API complains if the URL is sent encoded with `encodeURIComponent`.
Sending the URL in plain-text works.

Sending the URL-to-be-shortened to Google as `encodeURIComponent` value results in HTTP 400:
![error](https://cloud.githubusercontent.com/assets/469120/9129227/d96aee12-3cdd-11e5-93eb-56d7e867c85f.png)

Sending the raw URL works just fine:
![works](https://cloud.githubusercontent.com/assets/469120/9129228/d96b2d96-3cdd-11e5-8cb0-9352db44f382.png)

I'm using Hubot 2.14.0. Please verify, merge and tag a new release.
